### PR TITLE
Bugfix: Compare full sid/uid/gid, don't match substring

### DIFF
--- a/action_plugins/dcos_iam_group.py
+++ b/action_plugins/dcos_iam_group.py
@@ -50,14 +50,10 @@ def get_group_state(gid):
     display.vvv('looking for gid {}'.format(gid))
 
     state = 'absent'
-    for g in groups:
-        try:
-            if gid in g:
-                state = 'present'
-                display.vvv('found app: {}'.format(gid))
+    if gid in groups:
+        state = 'present'
+        display.vvv('found gid: {}'.format(gid))
 
-        except KeyError:
-         continue
     return state
 
 def group_create(gid, description):

--- a/action_plugins/dcos_iam_serviceaccount.py
+++ b/action_plugins/dcos_iam_serviceaccount.py
@@ -54,14 +54,10 @@ def get_service_account_state(sid):
     display.vvv('looking for sid {}'.format(sid))
 
     state = 'absent'
-    for g in service_accounts:
-        try:
-            if sid in g:
-                state = 'present'
-                display.vvv('found sid: {}'.format(sid))
+    if sid in service_accounts:
+        state = 'present'
+        display.vvv('found sid: {}'.format(sid))
 
-        except KeyError:
-         continue
     return state
 
 def service_account_create(sid, secret_path, store, description):

--- a/action_plugins/dcos_iam_user.py
+++ b/action_plugins/dcos_iam_user.py
@@ -50,14 +50,10 @@ def get_user_state(uid):
     display.vvv('looking for uid {}'.format(uid))
 
     state = 'absent'
-    for g in users:
-        try:
-            if uid in g:
-                state = 'present'
-                display.vvv('found uid: {}'.format(uid))
+    if uid in users:
+        state = 'present'
+        display.vvv('found uid: {}'.format(uid))
 
-        except KeyError:
-         continue
     return state
 
 def user_create(uid, password, description):


### PR DESCRIPTION
You cannot create a new user, if the new name is a substring of an already exisiting user.

The following will break in the second task:
```
- name: Create user foobar
  dcos_iam_user:
    uid: foobar
    ...
- name: Create user bar
  dcos_iam_user:
    uid: bar
    ...
```
Error message says something like cannot delete user 'bar'. 
This happens because get_user_state('bar') returns 'present' as it does not compare the full uid but only checks if one of the existing users contains the string 'bar' in its name. 
In the example 'foobar' was created before, thus 'bar' is reported to exist and the module tries to delete 'foobar' to recreate it. But the CLI cannot execute this delete, as in reality no user named 'bar' exists. Thus the second task breaks.